### PR TITLE
Added possibility to name the ToOne relationships

### DIFF
--- a/DaoGenerator/src/de/greenrobot/daogenerator/Entity.java
+++ b/DaoGenerator/src/de/greenrobot/daogenerator/Entity.java
@@ -140,6 +140,13 @@ public class Entity {
         return toOne;
     }
 
+    public ToOne addToOne(Entity target, Property fkProperty, String name) {
+        Property[] fkProperties = { fkProperty };
+        ToOne toOne = new ToOne(schema, this, target, fkProperties, true, name);
+        toOneRelations.add(toOne);
+        return toOne;
+    }
+    
     /** Add a to-many relationship; the target entity is joined to the PK property of this entity. */
     public ToMany addToMany(Entity target, Property targetProperty) {
         Property[] targetProperties = { targetProperty };

--- a/DaoGenerator/src/de/greenrobot/daogenerator/ToOne.java
+++ b/DaoGenerator/src/de/greenrobot/daogenerator/ToOne.java
@@ -37,6 +37,11 @@ public class ToOne {
         resolvedKeyUseEquals = new boolean[fkProperties.length];
     }
 
+    public ToOne(Schema schema, Entity sourceEntity, Entity targetEntity, Property[] fkProperties, boolean useFkProperty, String name) {
+    	this(schema, sourceEntity, targetEntity, fkProperties, useFkProperty);
+    	this.name = name;
+    }
+    
     public Entity getSourceEntity() {
         return sourceEntity;
     }


### PR DESCRIPTION
I added the possibility to create ToOne relationships with the following API:

```
    Property capitalLocationId = entCounty.addLongProperty("capitalLocationId").getProperty();
    entCounty.addToOne(entLocationInImage, capitalLocationId, "capitalLocation");
```

The last parameter is the name for the relationship. Normally when creating two properties in the traditional way addToOne(targetEntity, localProperty) the target entity class is used. This makes it impossible to add multiple toOne relationships to the baseEntity to the targetEntity. In my case the code looks like this:

```
    Property capitalLocationId = entCounty.addLongProperty("capitalLocationId").getProperty();
    entCounty.addToOne(entLocationInImage, capitalLocationId, "capitalLocation");
    Property countyLocationId = entCounty.addLongProperty("countyLocationId").getProperty();
    entCounty.addToOne(entLocationInImage, countyLocationId, "countyLocation");
```
