### PR TITLE
added AUTOINCREMENT property

### DIFF
--- a/DaoGenerator/src/de/greenrobot/daogenerator/Entity.java
+++ b/DaoGenerator/src/de/greenrobot/daogenerator/Entity.java
@@ -150,6 +150,13 @@ public class Entity {
         builder.columnName("_id").primaryKey();
         return builder;
     }
+    
+    /** Adds a standard _id column with an autoincrement required by standard Android classes, e.g. list adapters. */
+    public PropertyBuilder addIdPropertyAutoincremented() {
+        PropertyBuilder builder = addLongProperty("id");
+        builder.columnName("_id").primaryKeyAutoincrement();
+        return builder;
+    }
 
     /** Adds a to-many relationship; the target entity is joined to the PK property of this entity (typically the ID). */
     public ToMany addToMany(Entity target, Property targetProperty) {

--- a/DaoGenerator/src/de/greenrobot/daogenerator/Property.java
+++ b/DaoGenerator/src/de/greenrobot/daogenerator/Property.java
@@ -41,16 +41,36 @@ public class Property {
             property.primaryKey = true;
             return this;
         }
+        
+        public PropertyBuilder primaryKeyAutoincrement() {
+        	property.primaryKey = true;
+        	property.pkAutoincrement = true;
+        	return this;
+        }
 
         public PropertyBuilder primaryKeyAsc() {
             property.primaryKey = true;
             property.pkAsc = true;
             return this;
         }
-
+        
+        public PropertyBuilder primaryKeyAscAutoincrement() {
+            property.primaryKey = true;
+            property.pkAsc = true;
+            property.pkAutoincrement = true;
+            return this;
+        }
+        
         public PropertyBuilder primaryKeyDesc() {
             property.primaryKey = true;
             property.pkDesc = true;
+            return this;
+        }
+        
+        public PropertyBuilder primaryKeyDescAutoincrement() {
+            property.primaryKey = true;
+            property.pkDesc = true;
+            property.pkAutoincrement = true;
             return this;
         }
 
@@ -108,9 +128,11 @@ public class Property {
     private boolean primaryKey;
     private boolean pkAsc;
     private boolean pkDesc;
+    private boolean pkAutoincrement;
 
     private boolean unique;
     private boolean notNull;
+    
 
     /** Initialized in 2nd pass */
     private String constraints;
@@ -202,6 +224,9 @@ public class Property {
             }
             if (pkDesc) {
                 constraintBuilder.append(" DESC");
+            }
+            if (pkAutoincrement) {
+                constraintBuilder.append(" AUTOINCREMENT");
             }
         }
         if (notNull) {


### PR DESCRIPTION
With the AUTOINCREMENT property the database uses every identifier only
once. Without the AUTOINCREMENT the database uses former deleted ids
for new inserter rows
