### PR TITLE
Add listKeys method to query object

### DIFF
--- a/DaoCore/src/de/greenrobot/dao/AbstractDao.java
+++ b/DaoCore/src/de/greenrobot/dao/AbstractDao.java
@@ -477,7 +477,7 @@ public abstract class AbstractDao<T, K> {
      * arguments.
      */
     public Query<T> queryRawCreateListArgs(String where, Collection<Object> selectionArg) {
-        return Query.internalCreate(this, statements.getSelectAll() + where, selectionArg.toArray());
+        return Query.internalCreate(this, statements.getSelectAll() + where, statements.getSelectKey(getPkProperty()), selectionArg.toArray());
     }
 
     public void deleteAll() {
@@ -803,5 +803,27 @@ public abstract class AbstractDao<T, K> {
 
     /** Returns true if the Entity class can be updated, e.g. for setting the PK after insert. */
     abstract protected boolean isEntityUpdateable();
+    
+    /**
+     * Returns the primary keys from the given cursor 
+     * @param cursor the cursor to read keys from
+     * @param close if the cursor should be closed after reading the keys
+     * @return a list of primary keys or empty list
+     */
+	protected List<K> readKeys(Cursor cursor, boolean close) {
+		List<K> keys = new ArrayList<K>();
+    	if (cursor.moveToFirst()) {
+            try {
+                do {
+                	keys.add(readKey(cursor, 0));
+                } while (cursor.moveToNext());
+            } finally {
+            	if (close) {
+            		cursor.close();
+            	}
+            }
+        }
+    	return keys;
+	}
 
 }

--- a/DaoCore/src/de/greenrobot/dao/InternalQueryDaoAccess.java
+++ b/DaoCore/src/de/greenrobot/dao/InternalQueryDaoAccess.java
@@ -29,8 +29,13 @@ public final class InternalQueryDaoAccess<T> {
         return dao.getStatements();
     }
 
-    public static <T2> TableStatements getStatements(AbstractDao<T2, ?> dao) {
+    public static <T2, K2> TableStatements getStatements(AbstractDao<T2, K2> dao) {
         return dao.getStatements();
     }
+    
+	@SuppressWarnings("unchecked")
+	public <K> List<K> readKeys(Cursor cursor, boolean close) {
+		return (List<K>) dao.readKeys(cursor, close);
+	}
 
 }

--- a/DaoCore/src/de/greenrobot/dao/internal/TableStatements.java
+++ b/DaoCore/src/de/greenrobot/dao/internal/TableStatements.java
@@ -15,6 +15,7 @@
  */
 package de.greenrobot.dao.internal;
 
+import de.greenrobot.dao.Property;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 
@@ -30,6 +31,7 @@ public class TableStatements {
     private SQLiteStatement updateStatement;
     private SQLiteStatement deleteStatement;
 
+    private volatile String selectPk;
     private volatile String selectAll;
     private volatile String selectByKey;
     private volatile String selectByRowId;
@@ -73,6 +75,14 @@ public class TableStatements {
         return updateStatement;
     }
 
+
+	public String getSelectKey(Property pkProperty) {
+		if (selectPk == null) {
+			selectPk = SqlUtils.createSqlSelect(tablename, "T", new String[] { pkProperty.columnName });
+        }
+        return selectPk;
+	}
+    
     /** ends with an space to simplify appending to this string. */
     public String getSelectAll() {
         if (selectAll == null) {

--- a/DaoTest/src/de/greenrobot/daotest/query/QueryBuilderListKeysObjectsTest.java
+++ b/DaoTest/src/de/greenrobot/daotest/query/QueryBuilderListKeysObjectsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2011 Markus Junginger, greenrobot (http://greenrobot.de)
+ *
+ * This file is part of greenDAO Generator.
+ * 
+ * greenDAO Generator is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * greenDAO Generator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with greenDAO Generator.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.greenrobot.daotest.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.greenrobot.dao.query.QueryBuilder;
+import de.greenrobot.dao.test.AbstractDaoTestStringPk;
+import de.greenrobot.daotest.StringKeyValueEntity;
+import de.greenrobot.daotest.StringKeyValueEntityDao;
+
+public class QueryBuilderListKeysObjectsTest extends AbstractDaoTestStringPk<StringKeyValueEntityDao, StringKeyValueEntity> {
+
+    public QueryBuilderListKeysObjectsTest() {
+        super(StringKeyValueEntityDao.class);
+    }
+	
+    @Override
+    protected void setUp() {
+        super.setUp();
+        
+        QueryBuilder.LOG_SQL = true;
+        QueryBuilder.LOG_VALUES = true;
+    }
+    
+    public void testSize() {
+    	insert(3);
+    	
+    	List<String> keys = dao.queryBuilder().orderAsc(StringKeyValueEntityDao.Properties.Key).listKeys();
+    	
+    	assertEquals(3, keys.size());
+    }
+    
+    public void testValues() {
+    	insert(3);
+    	
+    	List<String> keys = dao.queryBuilder().orderAsc(StringKeyValueEntityDao.Properties.Key).listKeys();    	
+    	
+    	assertEquals("key0", keys.get(0));
+    	assertEquals("key1", keys.get(1));
+    	assertEquals("key2", keys.get(2));
+    }
+    
+    public void testEmpty() {
+    	dao.deleteAll();
+    	
+    	List<String> keys = dao.queryBuilder().listKeys();
+    	assertTrue(keys.isEmpty());
+    }
+
+	@Override
+	protected StringKeyValueEntity createEntity(String key) {
+		return createEntity(key, "default");
+	}
+	
+	protected StringKeyValueEntity createEntity(String key, String value) {
+		StringKeyValueEntity entity = new StringKeyValueEntity();
+		entity.setKey(key);
+		entity.setValue(value);
+		return entity;
+	}
+	
+	protected void insert(int num) {
+		List<StringKeyValueEntity> entities = new ArrayList<StringKeyValueEntity>();
+		for(int i = 0; i < num; i++) {
+			entities.add(createEntity("key" + i, "value" + i));
+		}
+		dao.insertInTx(entities);
+	}
+
+}

--- a/DaoTest/src/de/greenrobot/daotest/query/QueryBuilderListKeysTest.java
+++ b/DaoTest/src/de/greenrobot/daotest/query/QueryBuilderListKeysTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2011 Markus Junginger, greenrobot (http://greenrobot.de)
+ *
+ * This file is part of greenDAO Generator.
+ * 
+ * greenDAO Generator is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * greenDAO Generator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with greenDAO Generator.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.greenrobot.daotest.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.greenrobot.dao.query.Query;
+import de.greenrobot.dao.query.QueryBuilder;
+import de.greenrobot.daotest.TestEntity;
+import de.greenrobot.daotest.TestEntityDao;
+import de.greenrobot.daotest.entity.TestEntityTestBase;
+
+public class QueryBuilderListKeysTest extends TestEntityTestBase {
+	
+    @Override
+    protected void setUp() {
+        super.setUp();
+        
+        QueryBuilder.LOG_SQL = true;
+        QueryBuilder.LOG_VALUES = true;
+    }
+
+    public void testSize() {
+    	insert(3);
+    	
+    	List<Long> keys = dao.queryBuilder().listKeys();
+    	assertEquals(3, keys.size());
+    }
+    public void testValues() {        
+        List<TestEntity> entities = new ArrayList<TestEntity>();
+        entities.add(createEntity(1));
+        entities.add(createEntity(9));
+        entities.add(createEntity(12));
+        dao.insertInTx(entities);
+        
+        List<Long> keys = dao.queryBuilder().orderAsc(TestEntityDao.Properties.Id).listKeys();
+        assertEquals(3, keys.size());
+        assertEquals(Long.valueOf(1), (Long) keys.get(0));
+        assertEquals(Long.valueOf(9), (Long) keys.get(1));
+        assertEquals(Long.valueOf(12), (Long) keys.get(2));
+    }
+    
+    private TestEntity createEntity(long id) {
+    	TestEntity entity = new TestEntity();
+    	entity.setId(id);
+    	entity.setSimpleStringNotNull("green");
+    	return entity;
+    }
+
+    public void testBuildTwice() {
+        insert(3);
+
+        QueryBuilder<TestEntity> builder = dao.queryBuilder();
+        Query<TestEntity> query1 = builder.build();
+        Query<TestEntity> query2 = builder.build();
+        List<Long> keys1 = query1.listKeys();
+        List<Long> keys2 = query2.listKeys();
+        assertEquals(3, keys1.size());
+        assertEquals(3, keys2.size());
+        assertSame(keys1.get(1), keys2.get(1));
+    }
+    
+    public void testEmpty() {
+    	dao.deleteAll();
+    	
+    	List<Long> keys = dao.queryBuilder().listKeys();
+    	assertTrue(keys.isEmpty());
+    }
+
+}


### PR DESCRIPTION
I didn't want to refactor the AbstractQuery class and children to pass
the key type so this ugly method is required...

@SuppressWarnings("unchecked")
public <K> List<K> readKeys(Cursor cursor, boolean close) {
    return (List<K>) dao.readKeys(cursor, close);
}

To use for deletion it looks like this:
dao.deleteByKeyInTx(dao.queryBuilder().<Long>listKeys());

I grant greenrobot ownership of the code changes contained in this
commit.
