### PR TITLE
Generated code contain errors in javadoc and warnings

### DIFF
--- a/DaoGenerator/src-template/dao.ftl
+++ b/DaoGenerator/src-template/dao.ftl
@@ -61,6 +61,7 @@ import ${entity.javaPackage}.${entity.className}.Builder;
 /** 
  * DAO for table ${entity.tableName}.
 */
+@SuppressWarnings("ALL")
 public class ${entity.classNameDao} extends AbstractDao<${entity.className}, ${entity.pkType}> {
 
     public static final String TABLENAME = "${entity.tableName}";

--- a/DaoGenerator/src-template/entity.ftl
+++ b/DaoGenerator/src-template/entity.ftl
@@ -27,6 +27,7 @@ import java.util.List;
 </#if>
 <#if entity.active>
 import ${schema.defaultJavaPackageDao}.DaoSession;
+import de.greenrobot.dao.AbstractDao;
 import de.greenrobot.dao.DaoException;
 
 </#if>
@@ -47,6 +48,7 @@ import ${additionalImport};
 /**
  * Entity mapped to table ${entity.tableName}.
  */
+@SuppressWarnings("ALL")
 public class ${entity.className}<#if
 entity.superclass?has_content> extends ${entity.superclass} </#if><#if
 entity.interfacesToImplement?has_content> implements <#list entity.interfacesToImplement


### PR DESCRIPTION
Javadoc entries for Entities contain errors when they reference non-imported de.greenrobot.dao.AbstractDao.
Also generated code may contain many warnings, which do not point at actual issues and can generate much unnecessary output with code analysis tools.