### PR TITLE
Fix project import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
-sudo: false
 language: android
+# Use the Travis Container-Based Infrastructure
+sudo: false
 jdk:
   - oraclejdk7
 env:
+  global:
+    # increase adb timeout (2 minutes by default)
+    - ADB_INSTALL_TIMEOUT=8
   matrix:
     - ANDROID_SDKS=android-19,sysimg-19  ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
 android:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - ANDROID_SDKS=android-19,sysimg-19  ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
 android:
   components:
-    - build-tools-22.0.1
+    - build-tools-23.0.0
 before_install:
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
   - emulator -avd test -no-skin -no-audio -no-window &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: android
 jdk:
   - oraclejdk7

--- a/DaoCore/build.gradle
+++ b/DaoCore/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'de.greenrobot'
+archivesBaseName = 'greendao'
 version = '2.1.0-SNAPSHOT'
 sourceCompatibility = 1.6
 

--- a/DaoCore/settings.gradle
+++ b/DaoCore/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'greendao'

--- a/DaoExample/build.gradle
+++ b/DaoExample/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'de.greenrobot'
+archivesBaseName = 'greendao-example'
 version = '1.3.0'
 sourceCompatibility = 1.6
 

--- a/DaoExample/settings.gradle
+++ b/DaoExample/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'greendao-example'

--- a/DaoExampleGenerator/build.gradle
+++ b/DaoExampleGenerator/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven'
 apply plugin:'application'
 
 group = 'de.greenrobot'
+archivesBaseName = 'greendao-example-generator'
 version = '1.4.0-SNAPSHOT'
 sourceCompatibility = 1.6
 mainClassName = "de.greenrobot.daogenerator.gentest.ExampleDaoGenerator"

--- a/DaoExampleGenerator/settings.gradle
+++ b/DaoExampleGenerator/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'greendao-example-generator'

--- a/DaoGenerator/build.gradle
+++ b/DaoGenerator/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'de.greenrobot'
+archivesBaseName = 'greendao-generator'
 version = '2.0.0'
 sourceCompatibility = 1.6
 

--- a/DaoGenerator/settings.gradle
+++ b/DaoGenerator/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'greendao-generator'

--- a/DaoTest/build.gradle
+++ b/DaoTest/build.gradle
@@ -4,18 +4,18 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
     androidTestCompile project(':DaoCore')
 }
 
 android {
-    buildToolsVersion '22.0.1'
+    buildToolsVersion '23.0.0'
     compileSdkVersion 19
 
     sourceSets {

--- a/PerformanceTestOrmLite/build.gradle
+++ b/PerformanceTestOrmLite/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 
@@ -15,7 +15,7 @@ dependencies {
 }
 
 android {
-    buildToolsVersion '22.0.1'
+    buildToolsVersion '23.0.0'
     compileSdkVersion 19
 
     sourceSets {


### PR DESCRIPTION
Set artifact and archive names in `build.gradle` instead of `settings.gradle` as multiple settings files throw off Android Studio/IntelliJ.

Should fix #183.

Also resolves #211 (added `sudo: false` and did adjustments to travis config to ensure builds don't fail [due to timeouts](http://stackoverflow.com/questions/28949722/android-tests-fail-on-travis-with-shellcommandunresponsiveexception)).