### PR TITLE
Use generator library as "provided"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Gradle dependency for your Android app:
 
 Gradle dependency for your Java generator project:
 ```
-    compile 'de.greenrobot:greendao-generator:2.0.0'
+    provided 'de.greenrobot:greendao-generator:2.0.0'
 ```
 
 


### PR DESCRIPTION
The generator doesn't need to be in the APK, so "provided" is better than "compile" for this dependency type