### PR TITLE
Db abstraction

### DIFF
--- a/DaoCore/build.gradle
+++ b/DaoCore/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     provided 'com.google.android:android-test:4.1.1.4'
     provided 'com.google.android:annotations:4.1.1.4'
     provided 'com.google.android:support-v4:r7'
-    provided 'com.google.android:support-v4:r7'
 
     provided files('libs/sqlcipher.jar')
 

--- a/DaoCore/src/de/greenrobot/dao/database/AndroidSQLiteDatabase.java
+++ b/DaoCore/src/de/greenrobot/dao/database/AndroidSQLiteDatabase.java
@@ -32,6 +32,14 @@ public class AndroidSQLiteDatabase implements Database {
     }
 
     @Override
+    public Cursor query(String table, String[] columns,
+                        String where, String[] selectionArgs,
+                        String groupBy, String having, String orderBy, String limit) {
+        return delegate.query(table, columns, where, selectionArgs,
+                groupBy, having, orderBy, limit);
+    }
+
+    @Override
     public void execSQL(String sql) throws SQLException {
         delegate.execSQL(sql);
     }

--- a/DaoCore/src/de/greenrobot/dao/database/Database.java
+++ b/DaoCore/src/de/greenrobot/dao/database/Database.java
@@ -21,6 +21,10 @@ import android.database.SQLException;
 public interface Database {
     Cursor rawQuery(String sql, String[] selectionArgs);
 
+    Cursor query(String table, String[] columns,
+                 String where, String[] selectionArgs,
+                 String groupBy, String having, String orderBy, String limit);
+
     void execSQL(String sql) throws SQLException;
 
     void beginTransaction();

--- a/DaoCore/src/de/greenrobot/dao/database/SQLCipherDatabase.java
+++ b/DaoCore/src/de/greenrobot/dao/database/SQLCipherDatabase.java
@@ -32,6 +32,14 @@ public class SQLCipherDatabase implements Database {
     }
 
     @Override
+    public Cursor query(String table, String[] columns,
+                        String where, String[] selectionArgs,
+                        String groupBy, String having, String orderBy, String limit) {
+        return delegate.query(table, columns, where, selectionArgs,
+                groupBy, having, orderBy, limit);
+    }
+
+    @Override
     public void execSQL(String sql) throws SQLException {
         delegate.execSQL(sql);
     }


### PR DESCRIPTION
- remove unecessary provided dependency line from the gradle build descriptor

- add standard query method call to the underlying database implementations as available in previous implementations and clarify the rawQuery method