### PR TITLE
update readme for Android Studio users

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Gradle dependency for your Java generator project:
 ```
     compile 'org.greenrobot:greendao-generator:2.2.0'
 ```
+
+*Hint:* Use 'provided' if you are using the generator dependency in your Android project (in Android Studio for example), so it won't be included in your APK:
+```
+    provided 'org.greenrobot:greendao-generator:2.2.0'
+```
+
 *Note:* to use encrypted databases using SQLCipher, you need to reference different artifacts (postfix '-encryption'). For all details, please refer to the documentation on [database encryption](http://greenrobot.org/greendao/documentation/database-encryption/).
 
 Homepage, Documentation, Links


### PR DESCRIPTION
Using the generator-dependency in the Android project causes errors because of the freemarker library when building the APK. This can be avoided by using 'provided' instead of 'compile' and should be mentioned in the readme.