### PR TITLE
Property equality fix

### DIFF
--- a/DaoCore/src/main/java/de/greenrobot/dao/Property.java
+++ b/DaoCore/src/main/java/de/greenrobot/dao/Property.java
@@ -117,4 +117,29 @@ public class Property {
         return new PropertyCondition(this, " IS NOT NULL");
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if(object instanceof Property) {
+            Property property = (Property)object;
+            return ordinal == property.ordinal
+                    && type.equals(property.type)
+                    && name.equals(property.name)
+                    && primaryKey == property.primaryKey
+                    && columnName.equals(property.columnName);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return ordinal
+                ^ type.hashCode()
+                ^ name.hashCode()
+                ^ (primaryKey ? 1:0)
+                ^ columnName.hashCode();
+    }
+
 }

--- a/DaoCore/src/main/java/de/greenrobot/dao/query/WhereCollector.java
+++ b/DaoCore/src/main/java/de/greenrobot/dao/query/WhereCollector.java
@@ -79,7 +79,7 @@ class WhereCollector<T> {
             Property[] properties = dao.getProperties();
             boolean found = false;
             for (Property property2 : properties) {
-                if (property == property2) {
+                if (property.equals(property2)) {
                     found = true;
                     break;
                 }

--- a/DaoTest/src/test/java/de/greenrobot/dao/query/WhereCollectorTest.java
+++ b/DaoTest/src/test/java/de/greenrobot/dao/query/WhereCollectorTest.java
@@ -1,0 +1,41 @@
+package de.greenrobot.dao.query;
+
+import de.greenrobot.dao.unittest.*;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import de.greenrobot.dao.Property;
+import de.greenrobot.dao.query.WhereCollector;
+import de.greenrobot.daotest.dummyapp.BuildConfig;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 16)
+public class WhereCollectorTest {
+
+    private DaoSession daoSession;
+    private MinimalEntityDao minimalEntityDao;
+
+    @Before
+    public void setUp() {
+        DaoMaster.DevOpenHelper openHelper = new DaoMaster.DevOpenHelper(RuntimeEnvironment.application, null, null);
+        SQLiteDatabase db = openHelper.getWritableDatabase();
+        daoSession = new DaoMaster(db).newSession();
+        minimalEntityDao = daoSession.getMinimalEntityDao();
+    }
+
+    @Test
+    public void testCheckProperty() {
+    	WhereCollector whereCollector = new WhereCollector(minimalEntityDao, "T");
+    	final Property Id2 = new Property(0, Long.class, "id", true, "_id");
+
+    	whereCollector.checkProperty(Id2);
+    }
+
+}

--- a/DaoTest/src/test/java/de/greenrobot/dao/unittest/MinimalEntityTest.java
+++ b/DaoTest/src/test/java/de/greenrobot/dao/unittest/MinimalEntityTest.java
@@ -11,6 +11,7 @@ import org.robolectric.annotation.Config;
 
 import java.util.concurrent.CountDownLatch;
 
+import de.greenrobot.dao.Property;
 import de.greenrobot.dao.query.Query;
 import de.greenrobot.daotest.dummyapp.BuildConfig;
 
@@ -45,6 +46,12 @@ public class MinimalEntityTest {
         daoSession.update(entity);
         daoSession.delete(entity);
         assertNull(minimalEntityDao.load(entity.getId()));
+    }
+
+     @Test
+    public void testQueryBuilderEquality() {
+        final Property Id2 = new Property(0, Long.class, "id", true, "_id");
+        minimalEntityDao.queryBuilder().where(Id2.eq(0)).list();
     }
 
     @Test

--- a/DaoTest/src/test/java/de/greenrobot/dao/unittest/PropertyTest.java
+++ b/DaoTest/src/test/java/de/greenrobot/dao/unittest/PropertyTest.java
@@ -1,0 +1,41 @@
+package de.greenrobot.dao.unittest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+
+import de.greenrobot.dao.Property;
+import de.greenrobot.daotest.dummyapp.BuildConfig;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 16)
+public class PropertyTest {
+
+    @Test
+    public void testEquality() {
+        final Property a1Property = new Property(0, Long.class, "a", true, "_a");
+        final Property a2Property = new Property(0, Long.class, "a", true, "_a");
+
+        final Property bProperty = new Property(1, Long.class, "a", true, "_a");
+        final Property cProperty = new Property(0, Integer.class, "a", true, "_a");
+        final Property dProperty = new Property(0, Long.class, "b", true, "_a");
+        final Property eProperty = new Property(0, Long.class, "a", false, "_a");
+        final Property fProperty = new Property(0, Long.class, "a", true, "_b");
+
+        assertEquals(a1Property, a2Property);
+        assertNotSame(a1Property, a2Property);
+
+        assertFalse(a1Property.equals(bProperty));
+        assertFalse(a1Property.equals(cProperty));
+        assertFalse(a1Property.equals(dProperty));
+        assertFalse(a1Property.equals(eProperty));
+        assertFalse(a1Property.equals(fProperty));
+    }
+
+
+}


### PR DESCRIPTION
Added an equal implementation for Properties object. Ran into an issue which raised the following exception, was caused by evaluating the equality of two property objects using == instead of .equals(), within WhereCollector.java. I had managed to track the issue down to a poorly written unit test within my own codebase which I believe was mocking half of an object using powermock, in such a scenario == wasn't sufficient. I corrected the unit test, so its no longer a blocker to myself, however providing an equals implementation seems like a good thing to do anyway.

You may wish to remove the WhereCollector unit test as its somewhat redundant. Also whats the deal with the encryption branch. I assume pull requests are being made against master and master will then be merged into encryption before a release.

Ive also sent the contributor agreement.

Thanks,
Emmet

Original issue: https://github.com/greenrobot/greenDAO/issues/216

''''
throw new DaoException("Property '" + property.name + "' is not part of " + dao);
''''