### PR TITLE
Added AbstractQuery.getDao()

### DIFF
--- a/DaoCore/src/main/java/de/greenrobot/dao/query/AbstractQuery.java
+++ b/DaoCore/src/main/java/de/greenrobot/dao/query/AbstractQuery.java
@@ -83,4 +83,7 @@ abstract class AbstractQuery<T> {
         }
     }
 
+	public AbstractDao<T, ?> getDao() {
+		return dao;
+	}
 }


### PR DESCRIPTION
Used to check if the dao database isn't already closed to validate a saved query object.