### PR TITLE
Use correct compile statement in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ greenDAO is available on Maven Central. Please ensure that you are using the lat
 Add the following Gradle configuration to your Android project:
 ```
 buildscript {
+    repositories {
+        mavenCentral()
+    }
     dependencies {
         classpath 'org.greenrobot:greendao-gradle-plugin:3.0.0'
     }
@@ -34,7 +37,7 @@ buildscript {
 apply plugin: 'org.greenrobot.greendao'
  
 dependencies {
-    compile project('org.greenrobot:greendao:3.0.1')
+    compile 'org.greenrobot:greendao:3.0.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add greenDAO to your project
 greenDAO is available on Maven Central. Please ensure that you are using the latest versions by [checking here](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.greenrobot%22%20AND%20a%3A%22greendao%22) [and here](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.greenrobot%22%20AND%20a%3A%22greendao-generator%22)
 
 Add the following Gradle configuration to your Android project:
-```
+```groovy
 buildscript {
     repositories {
         mavenCentral()


### PR DESCRIPTION
- Explicitly add buildscript (Maven Central) repository, otherwise plugin will not be found.
- Closes #354

**Note:** this is also wrong in [the documentation](http://greenrobot.org/greendao/documentation/updating-to-greendao-3-and-annotations/#greenDAO_3_Gradle_Plugin).