### PR TITLE
Update Android Build Tools to 23.0.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - ANDROID_SDKS=android-23,sysimg-23  ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
 android:
   components:
-    - build-tools-23.0.1
+    - build-tools-23.0.3
     - android-23
     - extra-android-m2repository
 before_install:

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 ext {
-    buildToolsVersion = '23.0.1'
+    buildToolsVersion = '23.0.3'
     compileSdkVersion = 23
 
     minSdkVersion = 7


### PR DESCRIPTION
- Most notably: Improved the merging performance of the dx tool. https://developer.android.com/studio/releases/build-tools.html#notes