### PR TITLE
Use latest platform tools and tools with travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - ANDROID_SDKS=android-23,sysimg-23  ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
 android:
   components:
+    - platform-tools
+    - tools
     - build-tools-23.0.3
     - android-23
     - extra-android-m2repository


### PR DESCRIPTION
Fix the travis build tools not found error.