### PR TITLE
Added useCamelCaseNameWithoutInsertions

### DIFF
--- a/DaoGenerator/src-test/org/greenrobot/greendao/generator/SimpleDaoGeneratorTest.java
+++ b/DaoGenerator/src-test/org/greenrobot/greendao/generator/SimpleDaoGeneratorTest.java
@@ -53,11 +53,16 @@ public class SimpleDaoGeneratorTest {
 
     @Test
     public void testDbName() {
-        assertEquals("NORMAL", DaoUtil.dbName("normal"));
-        assertEquals("NORMAL", DaoUtil.dbName("Normal"));
-        assertEquals("CAMEL_CASE", DaoUtil.dbName("CamelCase"));
-        assertEquals("CAMEL_CASE_THREE", DaoUtil.dbName("CamelCaseThree"));
-        assertEquals("CAMEL_CASE_XXXX", DaoUtil.dbName("CamelCaseXXXX"));
+        assertEquals("NORMAL", DaoUtil.dbName("normal", false));
+        assertEquals("NORMAL", DaoUtil.dbName("Normal", false));
+        assertEquals("CAMEL_CASE", DaoUtil.dbName("CamelCase", false));
+        assertEquals("CAMEL_CASE_THREE", DaoUtil.dbName("CamelCaseThree", false));
+        assertEquals("CAMEL_CASE_XXXX", DaoUtil.dbName("CamelCaseXXXX", false));
+        assertEquals("NORMAL", DaoUtil.dbName("normal", true));
+        assertEquals("NORMAL", DaoUtil.dbName("Normal", true));
+        assertEquals("CAMELCASE", DaoUtil.dbName("CamelCase", true));
+        assertEquals("CAMELCASETHREE", DaoUtil.dbName("CamelCaseThree", true));
+        assertEquals("CAMELCASEXXXX", DaoUtil.dbName("CamelCaseXXXX", true));
     }
 
     @Test(expected = RuntimeException.class)

--- a/DaoGenerator/src/org/greenrobot/greendao/generator/DaoUtil.java
+++ b/DaoGenerator/src/org/greenrobot/greendao/generator/DaoUtil.java
@@ -27,14 +27,16 @@ import java.io.OutputStream;
 
 /** Internal API */
 public class DaoUtil {
-    public static String dbName(String javaName) {
+    public static String dbName(String javaName, boolean useCamelCaseNameWithoutInsertions) {
         StringBuilder builder = new StringBuilder(javaName);
-        for (int i = 1; i < builder.length(); i++) {
-            boolean lastWasUpper = Character.isUpperCase(builder.charAt(i - 1));
-            boolean isUpper = Character.isUpperCase(builder.charAt(i));
-            if (isUpper && !lastWasUpper) {
-                builder.insert(i, '_');
-                i++;
+        if(!useCamelCaseNameWithoutInsertions) {
+            for (int i = 1; i < builder.length(); i++) {
+                boolean lastWasUpper = Character.isUpperCase(builder.charAt(i - 1));
+                boolean isUpper = Character.isUpperCase(builder.charAt(i));
+                if (isUpper && !lastWasUpper) {
+                    builder.insert(i, '_');
+                    i++;
+                }
             }
         }
         return builder.toString().toUpperCase();

--- a/DaoGenerator/src/org/greenrobot/greendao/generator/Entity.java
+++ b/DaoGenerator/src/org/greenrobot/greendao/generator/Entity.java
@@ -558,7 +558,7 @@ public class Entity {
 
     protected void init2ndPassNamesWithDefaults() {
         if (tableName == null) {
-            tableName = DaoUtil.dbName(className);
+            tableName = DaoUtil.dbName(className, schema.isUseCamelCaseNameWithoutInsertions());
             nonDefaultTableName = false;
         }
 

--- a/DaoGenerator/src/org/greenrobot/greendao/generator/Property.java
+++ b/DaoGenerator/src/org/greenrobot/greendao/generator/Property.java
@@ -404,7 +404,7 @@ public class Property {
             columnType = schema.mapToDbType(propertyType);
         }
         if (columnName == null) {
-            columnName = DaoUtil.dbName(propertyName);
+            columnName = DaoUtil.dbName(propertyName, schema.isUseCamelCaseNameWithoutInsertions());
             nonDefaultColumnName = false;
         } else if (primaryKey && propertyType == PropertyType.Long && columnName.equals("_id")) {
             nonDefaultColumnName = false;

--- a/DaoGenerator/src/org/greenrobot/greendao/generator/Schema.java
+++ b/DaoGenerator/src/org/greenrobot/greendao/generator/Schema.java
@@ -42,6 +42,7 @@ public class Schema {
     private Map<PropertyType, String> propertyToJavaTypeNullable;
     private boolean hasKeepSectionsByDefault;
     private boolean useActiveEntitiesByDefault;
+    private boolean useCamelCaseNameWithoutInsertions;
     private final String name;
     private final String prefix;
 
@@ -65,6 +66,8 @@ public class Schema {
     public void enableActiveEntitiesByDefault() {
         useActiveEntitiesByDefault = true;
     }
+
+    public void enableCamelCaseNameWithoutInsertions() { useCamelCaseNameWithoutInsertions = true; }
 
     private void initTypeMappings() {
         propertyToDbType = new HashMap<>();
@@ -179,6 +182,8 @@ public class Schema {
     public boolean isUseActiveEntitiesByDefault() {
         return useActiveEntitiesByDefault;
     }
+
+    public boolean isUseCamelCaseNameWithoutInsertions() { return useCamelCaseNameWithoutInsertions; }
 
     public String getName() {
         return name;


### PR DESCRIPTION
I am currently working on several apps where I use greenDao to access a Sqlite database created by another module. This database does not include underscores in table and property names which consist of more than one word e.g. `DELETEDDATE`.

A solution for this issue would be to not use camel casing in the code’s table and property names e.g. `addDateProperty("Deleteddate")`, but this looks weird and does not fall in line with Google’s Java Style Guide Chapter 5.2.5 (https://google.github.io/styleguide/javaguide.html).

Another solution would be to use camel casing in the code’s table and property names and additionally specify the database naming e.g. `addDateProperty("DeletedDate").columnName("DELETEDDATE")`, but this approach is quite a hassle for a large amount of tables and properties (I can provide you with some examples).

Thus I implemented the possibility to generally switch off the underscore insertion for table and property names. 

```
Schema schema = new Schema(1, "com.demo.green");
schema.enableCamelCaseNameWithoutInsertions();
```

Feel free to accept the pull request if you like the changes, or ask me for further information.
