### PR TITLE
Gradle security update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.12'
+    gradleVersion = '2.14.1'
 }
 
 ext {
@@ -8,6 +8,14 @@ ext {
 
     minSdkVersion = 7
     targetSdkVersion = 23
+
+    // common dependencies for the example projects
+    dep = [
+            androidPlugin: 'com.android.tools.build:gradle:2.1.3',
+            greendaoPlugin: 'org.greenrobot:greendao-gradle-plugin:3.1.0',
+            appcompat: 'com.android.support:appcompat-v7:23.4.0',
+            recyclerview: 'com.android.support:recyclerview-v7:23.4.0'
+    ]
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/examples/DaoExample/build.gradle
+++ b/examples/DaoExample/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
-        classpath 'org.greenrobot:greendao-gradle-plugin:3.1.0'
+        classpath dep.androidPlugin
+        classpath dep.greendaoPlugin
     }
 }
 
@@ -33,8 +33,8 @@ greendao {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile "com.android.support:recyclerview-v7:23.4.0"
+    compile dep.appcompat
+    compile dep.recyclerview
 
     // in your app you would include "compile 'org.greenrobot:greendao:x.y.z'"
     compile project(':DaoCore')

--- a/examples/RxDaoExample/build.gradle
+++ b/examples/RxDaoExample/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
-        classpath 'org.greenrobot:greendao-gradle-plugin:3.1.0'
+        classpath dep.androidPlugin
+        classpath dep.greendaoPlugin
     }
 }
 
@@ -31,8 +31,8 @@ greendao {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile "com.android.support:recyclerview-v7:23.4.0"
+    compile dep.appcompat
+    compile dep.recyclerview
 
     // in your app you would include "compile 'org.greenrobot:greendao:x.y.z'"
     compile project(':DaoCore')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 31 20:39:08 CEST 2016
+#Tue Aug 16 09:33:25 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
- Update Gradle to 2.14.1.
- Move shared example dependencies to root gradle config file.