### PR TITLE
Use plugin versions defined in root config on test projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ ext {
     minSdkVersion = 7
     targetSdkVersion = 23
 
-    // common dependencies for the example projects
+    // common dependencies for Android projects
     dep = [
             androidPlugin: 'com.android.tools.build:gradle:2.1.3',
             greendaoPlugin: 'org.greenrobot:greendao-gradle-plugin:3.1.0',

--- a/tests/DaoTest/build.gradle
+++ b/tests/DaoTest/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath dep.androidPlugin
     }
 }
 

--- a/tests/DaoTestEntityAnnotation/build.gradle
+++ b/tests/DaoTestEntityAnnotation/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
-        classpath 'org.greenrobot:greendao-gradle-plugin:3.1.0'
+        classpath dep.androidPlugin
+        classpath dep.greendaoPlugin
     }
 }
 

--- a/tests/DaoTestPerformance/build.gradle
+++ b/tests/DaoTestPerformance/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath dep.androidPlugin
     }
 }
 


### PR DESCRIPTION
Now the Android plugin version is defined in one place for all example and test projects.