### PR TITLE
Add generateGettersSetters flag to Entity annotation.

### DIFF
--- a/greendao-api/build.gradle
+++ b/greendao-api/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 group = 'org.greenrobot'
-version = '3.1.0'
+version = '3.1.1-SNAPSHOT'
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/greendao-api/src/main/java/org/greenrobot/greendao/annotation/Entity.java
+++ b/greendao-api/src/main/java/org/greenrobot/greendao/annotation/Entity.java
@@ -45,8 +45,13 @@ public @interface Entity {
     boolean active() default false;
 
     /**
-     * Whether constructors should be generated.
+     * Whether an all properties constructor should be generated. A no-args constructor is always required.
      */
     boolean generateConstructors() default true;
+
+    /**
+     * Whether getters and setters for properties should be generated if missing.
+     */
+    boolean generateGettersSetters() default true;
 
 }


### PR DESCRIPTION
Closes #358.

This is only adds the flag to the `@Entity` annotation. Actual support is in the plugin code (changes in identical named `getters-setters-flag` branch).