### PR TITLE
Update examples to plugin version 3.2.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,11 @@ ext {
     minSdkVersion = 7
     targetSdkVersion = 25
 
-    // common dependencies for Android projects
+    // common dependencies
+    // do not use in example projects, so easy copy/paste is possible
     dep = [
             androidPlugin: 'com.android.tools.build:gradle:2.2.2',
-            greendaoPlugin: 'org.greenrobot:greendao-gradle-plugin:3.1.1',
-            appcompat: 'com.android.support:appcompat-v7:25.0.0',
-            recyclerview: 'com.android.support:recyclerview-v7:25.0.0'
+            greendaoPlugin: 'org.greenrobot:greendao-gradle-plugin:3.2.0'
     ]
 }
 

--- a/examples/DaoExample/build.gradle
+++ b/examples/DaoExample/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath dep.androidPlugin
-        classpath dep.greendaoPlugin
+        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'org.greenrobot:greendao-gradle-plugin:3.2.0'
     }
 }
 
@@ -14,13 +14,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
 
 android {
-    buildToolsVersion rootProject.ext.buildToolsVersion
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion '25.0.0'
+    compileSdkVersion 25
 
     defaultConfig {
         applicationId "org.greenrobot.greendao.example"
         minSdkVersion 15
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        targetSdkVersion 25
         versionCode 1
         versionName "3"
 
@@ -33,8 +33,9 @@ greendao {
 }
 
 dependencies {
-    compile dep.appcompat
-    compile dep.recyclerview
+    def supportLibVersion = '25.0.0'
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibVersion"
 
     // in your app you would include "compile 'org.greenrobot:greendao:x.y.z'"
     compile project(':DaoCore')

--- a/examples/RxDaoExample/build.gradle
+++ b/examples/RxDaoExample/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath dep.androidPlugin
-        classpath dep.greendaoPlugin
+        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'org.greenrobot:greendao-gradle-plugin:3.2.0'
     }
 }
 
@@ -14,13 +14,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
 
 android {
-    buildToolsVersion rootProject.ext.buildToolsVersion
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion '25.0.0'
+    compileSdkVersion 25
 
     defaultConfig {
         applicationId "org.greenrobot.greendao.rxexample"
         minSdkVersion 15
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -31,8 +31,9 @@ greendao {
 }
 
 dependencies {
-    compile dep.appcompat
-    compile dep.recyclerview
+    def supportLibVersion = '25.0.0'
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibVersion"
 
     // in your app you would include "compile 'org.greenrobot:greendao:x.y.z'"
     compile project(':DaoCore')


### PR DESCRIPTION
- Do not use root project variables to include dependencies to allow easy copy/paste.