### PR TITLE
DaoGenerator: loadDeep argument's type should be the same as entity's key

### DIFF
--- a/DaoGenerator/src-template/dao-deep.ftl
+++ b/DaoGenerator/src-template/dao-deep.ftl
@@ -61,7 +61,7 @@ along with greenDAO Generator.  If not, see <http://www.gnu.org/licenses/>.
         return entity;    
     }
 
-    public ${entity.className} loadDeep(Long key) {
+    public ${entity.className} loadDeep(${entity.pkType} key) {
         assertSinglePk();
         if (key == null) {
             return null;


### PR DESCRIPTION
I would love to test it this bugfix, but greendao gradle plugin source code isn't available at the moment.

@greenrobot @greenrobot-team is the any other option to test it?