### PR TITLE
loadRemaining() with lock

### DIFF
--- a/DaoCore/src/main/java/org/greenrobot/greendao/query/LazyList.java
+++ b/DaoCore/src/main/java/org/greenrobot/greendao/query/LazyList.java
@@ -151,9 +151,14 @@ public class LazyList<E> implements List<E>, Closeable {
     /** Loads the remaining entities (if any) that were not loaded before. Applies to cached lazy lists only. */
     public void loadRemaining() {
         checkCached();
-        int size = entities.size();
-        for (int i = 0; i < size; i++) {
-            get(i);
+        lock.lock();
+        try {
+            int size = entities.size();
+            for (int i = 0; i < size; i++) {
+                get(i);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
This prevents the many executions of `get(i)` from acquiring and releasing the lock all the time (as now, they will only increase and decrease the lock's counter).

I haven't tested this change.