### PR TITLE
Allow collation for SQLCipher databases.

### DIFF
--- a/DaoCore/src/main/java/org/greenrobot/greendao/query/QueryBuilder.java
+++ b/DaoCore/src/main/java/org/greenrobot/greendao/query/QueryBuilder.java
@@ -122,11 +122,8 @@ public class QueryBuilder<T> {
      * @see #preferLocalizedStringOrder
      */
     public QueryBuilder<T> stringOrderCollation(String stringOrderCollation) {
-        // SQLCipher 3.5.0+ does not understand "COLLATE LOCALIZED"
-        if (dao.getDatabase().getRawDatabase() instanceof SQLiteDatabase) {
-            this.stringOrderCollation = stringOrderCollation == null || stringOrderCollation.startsWith(" ") ?
-                    stringOrderCollation : " " + stringOrderCollation;
-        }
+        this.stringOrderCollation = stringOrderCollation == null || stringOrderCollation.startsWith(" ") ?
+                stringOrderCollation : " " + stringOrderCollation;
         return this;
     }
 


### PR DESCRIPTION
- Closes https://github.com/greenrobot/greenDAO/issues/727.
- SQLCipher just does not support collation that requires Android libraries
  (like 'COLLATE LOCALIZED'). Everything else standard SQLite is supported,
  so allow it.