### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ buildscript {
         mavenCentral() // add repository
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'org.greenrobot:greendao-gradle-plugin:3.2.2' // add plugin
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
 
     // common dependencies for Android projects (not to be used in example projects for better copy and paste)
     dep = [
-            androidPlugin: 'com.android.tools.build:gradle:3.2.1',
+            androidPlugin: 'com.android.tools.build:gradle:3.5.3',
             greendaoPlugin: 'org.greenrobot:greendao-gradle-plugin:3.2.2'
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ wrapper {
 }
 
 ext {
-    compileSdkVersion = 27
+    compileSdkVersion = 29
 
     minSdkVersion = 7
     targetSdkVersion = 25

--- a/examples/DaoExample/build.gradle
+++ b/examples/DaoExample/build.gradle
@@ -15,12 +15,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "org.greenrobot.greendao.example"
         minSdkVersion 15
-        targetSdkVersion 27
+        targetSdkVersion 29
         versionCode 1
         versionName "3"
 

--- a/examples/DaoExample/build.gradle
+++ b/examples/DaoExample/build.gradle
@@ -17,6 +17,10 @@ apply plugin: 'org.greenrobot.greendao'
 android {
     compileSdkVersion 29
 
+    // To use deprecated test classes on SDK 28+. https://developer.android.com/training/testing/set-up-project
+    useLibrary 'android.test.runner'
+    useLibrary 'android.test.base'
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/examples/DaoExample/build.gradle
+++ b/examples/DaoExample/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     // optional: add if you want to use encrypted databases, see the App class for details
     // implementation 'net.zetetic:android-database-sqlcipher:3.5.6'
 
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
 }
 
 uploadArchives.enabled = false

--- a/examples/DaoExample/build.gradle
+++ b/examples/DaoExample/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'org.greenrobot:greendao-gradle-plugin:3.2.2'
     }
 }

--- a/examples/DaoExample/build.gradle
+++ b/examples/DaoExample/build.gradle
@@ -17,6 +17,11 @@ apply plugin: 'org.greenrobot.greendao'
 android {
     compileSdkVersion 29
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "org.greenrobot.greendao.example"
         minSdkVersion 15

--- a/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NoteActivity.java
+++ b/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NoteActivity.java
@@ -16,9 +16,6 @@
 package org.greenrobot.greendao.example;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -34,6 +31,10 @@ import org.greenrobot.greendao.query.Query;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class NoteActivity extends AppCompatActivity {
 
@@ -66,8 +67,7 @@ public class NoteActivity extends AppCompatActivity {
     }
 
     protected void setUpViews() {
-        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recyclerViewNotes);
-        //noinspection ConstantConditions
+        RecyclerView recyclerView = findViewById(R.id.recyclerViewNotes);
         recyclerView.setHasFixedSize(true);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
@@ -75,10 +75,9 @@ public class NoteActivity extends AppCompatActivity {
         recyclerView.setAdapter(notesAdapter);
 
         addNoteButton = findViewById(R.id.buttonAdd);
-        //noinspection ConstantConditions
         addNoteButton.setEnabled(false);
 
-        editText = (EditText) findViewById(R.id.editTextNote);
+        editText = findViewById(R.id.editTextNote);
         editText.setOnEditorActionListener(new OnEditorActionListener() {
 
             @Override

--- a/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NoteActivity.java
+++ b/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NoteActivity.java
@@ -19,12 +19,9 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
-import android.widget.TextView;
-import android.widget.TextView.OnEditorActionListener;
 
 import org.greenrobot.greendao.query.Query;
 
@@ -78,16 +75,12 @@ public class NoteActivity extends AppCompatActivity {
         addNoteButton.setEnabled(false);
 
         editText = findViewById(R.id.editTextNote);
-        editText.setOnEditorActionListener(new OnEditorActionListener() {
-
-            @Override
-            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                if (actionId == EditorInfo.IME_ACTION_DONE) {
-                    addNote();
-                    return true;
-                }
-                return false;
+        editText.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                addNote();
+                return true;
             }
+            return false;
         });
         editText.addTextChangedListener(new TextWatcher() {
 

--- a/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NotesAdapter.java
+++ b/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NotesAdapter.java
@@ -29,12 +29,9 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
             super(itemView);
             text = itemView.findViewById(R.id.textViewNoteText);
             comment = itemView.findViewById(R.id.textViewNoteComment);
-            itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    if (clickListener != null) {
-                        clickListener.onNoteClick(getAdapterPosition());
-                    }
+            itemView.setOnClickListener(view -> {
+                if (clickListener != null) {
+                    clickListener.onNoteClick(getAdapterPosition());
                 }
             });
         }

--- a/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NotesAdapter.java
+++ b/examples/DaoExample/src/main/java/org/greenrobot/greendao/example/NotesAdapter.java
@@ -1,13 +1,15 @@
 package org.greenrobot.greendao.example;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHolder> {
 
@@ -25,8 +27,8 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
         public NoteViewHolder(View itemView, final NoteClickListener clickListener) {
             super(itemView);
-            text = (TextView) itemView.findViewById(R.id.textViewNoteText);
-            comment = (TextView) itemView.findViewById(R.id.textViewNoteComment);
+            text = itemView.findViewById(R.id.textViewNoteText);
+            comment = itemView.findViewById(R.id.textViewNoteComment);
             itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
@@ -40,7 +42,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
     public NotesAdapter(NoteClickListener clickListener) {
         this.clickListener = clickListener;
-        this.dataset = new ArrayList<Note>();
+        this.dataset = new ArrayList<>();
     }
 
     public void setNotes(@NonNull List<Note> notes) {
@@ -52,6 +54,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         return dataset.get(position);
     }
 
+    @NonNull
     @Override
     public NotesAdapter.NoteViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())

--- a/examples/DaoExample/src/main/res/layout/main.xml
+++ b/examples/DaoExample/src/main/res/layout/main.xml
@@ -39,7 +39,7 @@
         android:text="@string/click_to_remove"
         android:textSize="12sp"/>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewNotes"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/examples/RxDaoExample/build.gradle
+++ b/examples/RxDaoExample/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     implementation 'io.reactivex:rxandroid:1.2.1'
     implementation 'io.reactivex:rxjava:1.3.0'
 
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
 }
 
 uploadArchives.enabled = false

--- a/examples/RxDaoExample/build.gradle
+++ b/examples/RxDaoExample/build.gradle
@@ -17,6 +17,11 @@ apply plugin: 'org.greenrobot.greendao'
 android {
     compileSdkVersion 29
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "org.greenrobot.greendao.rxexample"
         minSdkVersion 15

--- a/examples/RxDaoExample/build.gradle
+++ b/examples/RxDaoExample/build.gradle
@@ -15,12 +15,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "org.greenrobot.greendao.rxexample"
         minSdkVersion 15
-        targetSdkVersion 27
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/examples/RxDaoExample/build.gradle
+++ b/examples/RxDaoExample/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'org.greenrobot:greendao-gradle-plugin:3.2.2'
     }
 }

--- a/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/MainActivity.java
+++ b/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/MainActivity.java
@@ -7,20 +7,17 @@ import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 
 import com.jakewharton.rxbinding.widget.RxTextView;
-import com.jakewharton.rxbinding.widget.TextViewAfterTextChangeEvent;
 
 import org.greenrobot.greendao.rx.RxDao;
 import org.greenrobot.greendao.rx.RxQuery;
 
 import java.text.DateFormat;
 import java.util.Date;
-import java.util.List;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import rx.android.schedulers.AndroidSchedulers;
-import rx.functions.Action1;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -50,12 +47,7 @@ public class MainActivity extends AppCompatActivity {
     private void updateNotes() {
         notesQuery.list()
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Action1<List<Note>>() {
-                    @Override
-                    public void call(List<Note> notes) {
-                        notesAdapter.setNotes(notes);
-                    }
-                });
+                .subscribe(notes -> notesAdapter.setNotes(notes));
     }
 
     protected void setUpViews() {
@@ -70,21 +62,15 @@ public class MainActivity extends AppCompatActivity {
 
         editText = findViewById(R.id.editTextNote);
         RxTextView.editorActions(editText).observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Action1<Integer>() {
-                    @Override
-                    public void call(Integer actionId) {
-                        if (actionId == EditorInfo.IME_ACTION_DONE) {
-                            addNote();
-                        }
+                .subscribe(actionId -> {
+                    if (actionId == EditorInfo.IME_ACTION_DONE) {
+                        addNote();
                     }
                 });
         RxTextView.afterTextChangeEvents(editText).observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Action1<TextViewAfterTextChangeEvent>() {
-                    @Override
-                    public void call(TextViewAfterTextChangeEvent textViewAfterTextChangeEvent) {
-                        boolean enable = textViewAfterTextChangeEvent.editable().length() > 0;
-                        addNoteButton.setEnabled(enable);
-                    }
+                .subscribe(textViewAfterTextChangeEvent -> {
+                    boolean enable = textViewAfterTextChangeEvent.editable().length() > 0;
+                    addNoteButton.setEnabled(enable);
                 });
     }
 
@@ -102,12 +88,9 @@ public class MainActivity extends AppCompatActivity {
         Note note = new Note(null, noteText, comment, new Date(), NoteType.TEXT);
         noteDao.insert(note)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Action1<Note>() {
-                    @Override
-                    public void call(Note note) {
-                        Log.d("DaoExample", "Inserted new note, ID: " + note.getId());
-                        updateNotes();
-                    }
+                .subscribe(note1 -> {
+                    Log.d("DaoExample", "Inserted new note, ID: " + note1.getId());
+                    updateNotes();
                 });
     }
 
@@ -119,12 +102,9 @@ public class MainActivity extends AppCompatActivity {
 
             noteDao.deleteByKey(noteId)
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(new Action1<Void>() {
-                        @Override
-                        public void call(Void aVoid) {
-                            Log.d("DaoExample", "Deleted note, ID: " + noteId);
-                            updateNotes();
-                        }
+                    .subscribe(aVoid -> {
+                        Log.d("DaoExample", "Deleted note, ID: " + noteId);
+                        updateNotes();
                     });
         }
     };

--- a/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/MainActivity.java
+++ b/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/MainActivity.java
@@ -1,9 +1,6 @@
 package org.greenrobot.greendao.rxexample;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
@@ -19,6 +16,9 @@ import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
 
@@ -59,8 +59,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     protected void setUpViews() {
-        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recyclerViewNotes);
-        //noinspection ConstantConditions
+        RecyclerView recyclerView = findViewById(R.id.recyclerViewNotes);
         recyclerView.setHasFixedSize(true);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
@@ -69,8 +68,7 @@ public class MainActivity extends AppCompatActivity {
 
         addNoteButton = findViewById(R.id.buttonAdd);
 
-        editText = (EditText) findViewById(R.id.editTextNote);
-        //noinspection ConstantConditions
+        editText = findViewById(R.id.editTextNote);
         RxTextView.editorActions(editText).observeOn(AndroidSchedulers.mainThread())
                 .subscribe(new Action1<Integer>() {
                     @Override

--- a/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/NotesAdapter.java
+++ b/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/NotesAdapter.java
@@ -29,12 +29,9 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
             super(itemView);
             text = itemView.findViewById(R.id.textViewNoteText);
             comment = itemView.findViewById(R.id.textViewNoteComment);
-            itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    if (clickListener != null) {
-                        clickListener.onNoteClick(getAdapterPosition());
-                    }
+            itemView.setOnClickListener(view -> {
+                if (clickListener != null) {
+                    clickListener.onNoteClick(getAdapterPosition());
                 }
             });
         }

--- a/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/NotesAdapter.java
+++ b/examples/RxDaoExample/src/main/java/org/greenrobot/greendao/rxexample/NotesAdapter.java
@@ -1,7 +1,5 @@
 package org.greenrobot.greendao.rxexample;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -9,6 +7,9 @@ import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHolder> {
 
@@ -26,8 +27,8 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
         public NoteViewHolder(View itemView, final NoteClickListener clickListener) {
             super(itemView);
-            text = (TextView) itemView.findViewById(R.id.textViewNoteText);
-            comment = (TextView) itemView.findViewById(R.id.textViewNoteComment);
+            text = itemView.findViewById(R.id.textViewNoteText);
+            comment = itemView.findViewById(R.id.textViewNoteComment);
             itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
@@ -41,7 +42,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
     public NotesAdapter(NoteClickListener clickListener) {
         this.clickListener = clickListener;
-        this.dataset = new ArrayList<Note>();
+        this.dataset = new ArrayList<>();
     }
 
     public void setNotes(@NonNull List<Note> notes) {
@@ -53,6 +54,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         return dataset.get(position);
     }
 
+    @NonNull
     @Override
     public NotesAdapter.NoteViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())

--- a/examples/RxDaoExample/src/main/res/layout/activity_main.xml
+++ b/examples/RxDaoExample/src/main/res/layout/activity_main.xml
@@ -39,7 +39,7 @@
         android:text="@string/click_to_remove"
         android:textSize="12sp"/>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewNotes"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx1536M
 
 android.enableJetifier=true
 android.useAndroidX=true
+
+# TODO Update Robolectric to latest 4.x and remove this.
+android.enableUnitTestBinaryResources=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,6 @@
 # org.gradle.parallel=true
 #Tue Jan 28 11:11:04 CET 2020
 org.gradle.jvmargs=-Xmx1536M
+
+android.enableJetifier=true
+android.useAndroidX=true

--- a/tests/DaoTest/build.gradle
+++ b/tests/DaoTest/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    // To use deprecated test classes on SDK 28+. https://developer.android.com/training/testing/set-up-project
+    useLibrary 'android.test.runner'
+    useLibrary 'android.test.base'
+
     defaultConfig {
         minSdkVersion 7
 

--- a/tests/DaoTestEntityAnnotation/build.gradle
+++ b/tests/DaoTestEntityAnnotation/build.gradle
@@ -17,6 +17,10 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    // To use deprecated test classes on SDK 28+. https://developer.android.com/training/testing/set-up-project
+    useLibrary 'android.test.runner'
+    useLibrary 'android.test.base'
+
     defaultConfig {
         applicationId "org.greenrobot.greendao.test.entityannotation"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/tests/DaoTestPerformance/build.gradle
+++ b/tests/DaoTestPerformance/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    // To use deprecated test classes on SDK 28+. https://developer.android.com/training/testing/set-up-project
+    useLibrary 'android.test.runner'
+    useLibrary 'android.test.base'
+
     defaultConfig {
         minSdkVersion 5
         testApplicationId "org.greenrobot.greendao.perftest"


### PR DESCRIPTION
- Update Android Plugin [3.2.1 -> 3.5.3].
- Compile with SDK 29, for examples also target SDK 29.
- Examples:
  - migrate to AndroidX, remove redundant casts, code clean-up.
  - use Java 8 features.
- Add required Android JUnit test classes removed in SDK 28.
- Robolectric workaround: set enableUnitTestBinaryResources false.